### PR TITLE
Fixed Luv_to_XYZ transformation

### DIFF
--- a/colormath/color_conversions.py
+++ b/colormath/color_conversions.py
@@ -260,7 +260,7 @@ def Luv_to_XYZ(cobj, debug=False, *args, **kwargs):
     xyzcolor = _color_objects().XYZColor()
     _transfer_common(cobj, xyzcolor)
     illum = xyzcolor.get_illuminant_xyz()
-    
+
     # Without Light, there is no color. Short-circuit this and avoid some
     # zero division errors in the var_a_frac calculation.
     if cobj.luv_l <= 0.0:
@@ -268,31 +268,25 @@ def Luv_to_XYZ(cobj, debug=False, *args, **kwargs):
         xyzcolor.xyz_y = 0.0
         xyzcolor.xyz_z = 0.0
         return xyzcolor
-   
+
     # Various variables used throughout the conversion.
     cie_k_times_e = color_constants.CIE_K * color_constants.CIE_E
     u_sub_0 = (4.0 * illum["X"]) / (illum["X"] + 15.0 * illum["Y"] + 3.0 * illum["Z"])
     v_sub_0 = (9.0 * illum["Y"]) / (illum["X"] + 15.0 * illum["Y"] + 3.0 * illum["Z"])
-    var_a_frac = (52.0 * cobj.luv_l) / (cobj.luv_u + 13.0 * cobj.luv_l * u_sub_0) 
-    var_a = (1.0/3.0) * (var_a_frac - 1.0)
-    var_c = -(1.0/3.0)
-   
+    var_u = cobj.luv_u / (13.0 * cobj.luv_l) + u_sub_0
+    var_v = cobj.luv_v / (13.0 * cobj.luv_l) + v_sub_0
+
     # Y-coordinate calculations.
     if cobj.luv_l > cie_k_times_e:
         xyzcolor.xyz_y = math.pow((cobj.luv_l + 16.0) / 116.0, 3.0)
     else:
         xyzcolor.xyz_y = cobj.luv_l / color_constants.CIE_K
-      
-    # These variables depend on Y-coordinate being solved.
-    var_b = -5.0 * xyzcolor.xyz_y 
-    var_d_frac = (39.0 * cobj.luv_l) / (cobj.luv_v + 13.0 * cobj.luv_l * v_sub_0)
-    var_d = xyzcolor.xyz_y * (var_d_frac - 5.0)
-   
+
     # X-coordinate calculation.
-    xyzcolor.xyz_x = (var_d - var_b) / (var_a - var_c)
+    xyzcolor.xyz_x = xyzcolor.xyz_y * 9.0 * var_u / (4.0 * var_v)
     # Z-coordinate calculation.
-    xyzcolor.xyz_z = xyzcolor.xyz_x * var_a + var_b
-   
+    xyzcolor.xyz_z = xyzcolor.xyz_y * (12.0 - 3.0 * var_u - 20.0 * var_v) / (4.0 * var_v)
+
     return xyzcolor
 
 def LCHab_to_Lab(cobj, debug=False, *args, **kwargs):


### PR DESCRIPTION
Hi Greg,

your current Luv_to_XYZ code seems to be adapted from http://brucelindbloom.com/index.html?Eqn_Luv_to_XYZ.html, but as far as I can see, these formulas aren't correct. They produce different results than http://www.easyrgb.com/index.php?X=CALC and my own code based on http://en.wikipedia.org/wiki/CIELUV (while their results are equal), so I fixed the routine to follow the agorithm from Wikipedia. The reverse transformation already the same as in the Wikipedia, and now XYZ_to_Luv(Luv_to_XYZ(luv_color)) actually returns luv_color, which wasn't the case before.

Cheers.
