### PR TITLE
setup.py: Fix required dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(
     license='BSD',
     classifiers=CLASSIFIERS,
     keywords=KEYWORDS,
-    requires=['numpy']
+    install_requires=['numpy', 'networkx'],
 )


### PR DESCRIPTION
The documented requirement argument seems to be 'install_requires', so
use that. Also, 'networkx' is needed if 'python setup.py
{install,develop}' should work. Lastly, add a comma for good style (as
with CLASSIFIERS).