### PR TITLE
Add AppleRGBColor

### DIFF
--- a/colormath/color_objects.py
+++ b/colormath/color_objects.py
@@ -689,6 +689,39 @@ class AdobeRGBColor(BaseRGBColor):
     }
 
 
+class AppleRGBColor(BaseRGBColor):
+    """
+    Represents an AppleRGB color.
+
+    .. note:: If you pass in upscaled values, we automatically scale them
+        down to 0.0-1.0. If you need the old upscaled values, you can
+        retrieve them with :py:meth:`get_upscaled_value_tuple`.
+
+    :ivar float rgb_r: R coordinate
+    :ivar float rgb_g: G coordinate
+    :ivar float rgb_b: B coordinate
+    :ivar bool is_upscaled: If True, RGB values are between 1-255. If False,
+        0.0-1.0.
+    """
+
+    #: RGB space's gamma constant.
+    rgb_gamma = 1.8
+    #: The RGB space's native illuminant. Important when converting to XYZ.
+    native_illuminant = "d65"
+    conversion_matrices = {
+        "xyz_to_rgb":
+            numpy.array((
+                (2.9515373, -1.2894116, -0.4738445),
+                (-1.0851093, 1.9908566, 0.0372026),
+                (0.0854934, -0.2694964, 1.0912975))),
+        "rgb_to_xyz":
+            numpy.array((
+                (0.4497288, 0.3162486, 0.1844926),
+                (0.2446525, 0.6720283, 0.0833192),
+                (0.0251848, 0.1411824, 0.9224628))),
+    }
+
+
 class HSLColor(ColorBase):
     """
     Represents an HSL color.

--- a/tests/test_color_objects.py
+++ b/tests/test_color_objects.py
@@ -7,7 +7,7 @@ import unittest
 from colormath.color_conversions import convert_color
 from colormath.color_objects import SpectralColor, XYZColor, xyYColor, \
     LabColor, LuvColor, LCHabColor, LCHuvColor, sRGBColor, HSLColor, HSVColor, \
-    CMYColor, CMYKColor, AdobeRGBColor, IPTColor
+    CMYColor, CMYKColor, AdobeRGBColor, AppleRGBColor, IPTColor
 
 
 class BaseColorConversionTest(unittest.TestCase):
@@ -94,6 +94,11 @@ class XYZConversionTestCase(BaseColorConversionTest):
         self.color = XYZColor(0.300, 0.200, 0.300)
         rgb = convert_color(self.color, sRGBColor)
         self.assertColorMatch(rgb, sRGBColor(0.715, 0.349, 0.663))
+
+    def test_conversion_to_apple_rgb(self):
+        self.color = XYZColor(0.0157, 0.0191, 0.0331)
+        rgb = convert_color(self.color, AppleRGBColor)
+        self.assertColorMatch(rgb, AppleRGBColor(0.0411, 0.1214, 0.1763))
 
     def test_conversion_to_adobe_rgb(self):
         self.color = XYZColor(0.2553, 0.1125, 0.0011)


### PR DESCRIPTION
First of all: very nice library, thanks a lot for publishing it!

I need to do some transformations from sRGB to Apple RGB, so why not add AppleRGBColor class?

I have copied transformation matrices from
http://www.brucelindbloom.com/Eqn_RGB_XYZ_Matrix.html#WSMatrices
and the other constants (illuminant and gamma) from
http://www.brucelindbloom.com/index.html?WorkingSpaceInfo.html#ColorSets

As far as I can tell this is the same Apple RGB space as is available in
Adobe Photoshop.

I hope I did this right - I'm pretty new to color space transformations... Let me know if something's wrong.

Thanks!