### PR TITLE
Implement support for "ITU-R BT.2020" colorspace.

### DIFF
--- a/colormath/color_objects.py
+++ b/colormath/color_objects.py
@@ -634,6 +634,39 @@ class sRGBColor(BaseRGBColor):
     }
 
 
+class BT2020Color(BaseRGBColor):
+    """
+    Represents a ITU-R BT.2020 color.
+
+    .. note:: If you pass in upscaled values, we automatically scale them
+        down to 0.0-1.0. If you need the old upscaled values, you can
+        retrieve them with :py:meth:`get_upscaled_value_tuple`.
+
+    :ivar float rgb_r: R coordinate
+    :ivar float rgb_g: G coordinate
+    :ivar float rgb_b: B coordinate
+    :ivar bool is_upscaled: If True, RGB values are between 1-255. If False,
+        0.0-1.0.
+    """
+
+    #: RGB space's gamma constant.
+    rgb_gamma = 2.4
+    #: The RGB space's native illuminant. Important when converting to XYZ.
+    native_illuminant = "d65"
+    conversion_matrices = {
+        "xyz_to_rgb":
+            numpy.array((
+                (1.716651187971269, -0.355670783776393, -0.253366281373660),
+                (-0.666684351832489, 1.616481236634939, 0.015768545813911),
+                (0.017639857445311, -0.042770613257809, 0.942103121235474))),
+        "rgb_to_xyz":
+            numpy.array((
+                (0.636958048301291, 0.144616903586208, 0.168880975164172),
+                (0.262700212011267, 0.677998071518871, 0.059301716469862),
+                (0.000000000000000, 0.028072693049087, 1.060985057710791))),
+    }
+
+
 class AdobeRGBColor(BaseRGBColor):
     """
     Represents an Adobe RGB color.

--- a/doc_src/color_objects.rst
+++ b/doc_src/color_objects.rst
@@ -48,6 +48,11 @@ sRGBColor
 
 .. autoclass:: colormath.color_objects.sRGBColor
 
+BT2020Color
+-----------
+
+.. autoclass:: colormath.color_objects.BT2020Color
+
 AdobeRGBColor
 -------------
 

--- a/tests/test_color_conversion.py
+++ b/tests/test_color_conversion.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 import itertools
+import numpy as np
 import unittest
 from colormath import color_conversions
-from colormath.color_conversions import GraphConversionManager, XYZ_to_RGB, HSV_to_RGB
+from colormath.color_conversions import GraphConversionManager, XYZ_to_RGB, HSV_to_RGB, \
+                                        RGB_to_XYZ
 from colormath.color_exceptions import UndefinedConversionError
-from colormath.color_objects import XYZColor, BaseRGBColor, HSVColor, HSLColor
+from colormath.color_objects import XYZColor, BaseRGBColor, HSVColor, HSLColor, \
+                                    AdobeRGBColor, BT2020Color, sRGBColor
 
 
 class GraphConversionManagerTestCase(unittest.TestCase):
@@ -52,3 +55,17 @@ class ColorConversionTestCase(unittest.TestCase):
                 # Otherwise check that all the conversion functions math up
                 for a, b in zip(path[:-1], path[1:]):
                     self.assertEqual(a.target_type, b.start_type)
+
+    def test_transfer_functions(self):
+        """
+        Tests the transfer functions of the various RGB colorspaces.
+        """
+
+        for colorspace in (AdobeRGBColor, BT2020Color, sRGBColor):
+            for a in (0.0, 0.01, 0.18, 1.0):
+                RGB = [a] * 3
+            np.testing.assert_allclose(
+                XYZ_to_RGB(RGB_to_XYZ(colorspace(*RGB)), colorspace).get_value_tuple(),
+                RGB,
+                rtol=1e-5,
+                atol=1e-5)


### PR DESCRIPTION
A few notes:

- The conversion matrices and some of the transfer functions constants are computed with [colour](https://github.com/colour-science/colour). I did not added a reference as there are no references atm in the codebase.
- The way transfer functions are implemented as of now, i.e. in the `RGB_to_XYZ` and `XYZ_to_RGB` definitions is not very maintainable which is fine assuming only a few colorspaces are implemented.
- The matrices of the various RGB colorspaces don't round trip properly, I would suggest keeping the NPM and have the inverse computed with `np.linalg.inv`.
- I added a round-trip test for the RGB colorspace with transfer functions in mind, could be extended but it is a start.