### PR TITLE
Enable Python 3.7, 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 # command to install dependencies
 install: "pip install -r requirements.txt"
 # command to run tests

--- a/colormath/chromatic_adaptation.py
+++ b/colormath/chromatic_adaptation.py
@@ -83,7 +83,7 @@ def apply_chromatic_adaptation(val_x, val_y, val_z, orig_illum, targ_illum,
     elif hasattr(targ_illum, '__iter__'):
         wp_dst = targ_illum
 
-    logger.debug("  \* Applying adaptation matrix: %s", adaptation)
+    logger.debug("  \\* Applying adaptation matrix: %s", adaptation)
     # Retrieve the appropriate transformation matrix from the constants.
     transform_matrix = _get_adaptation_matrix(wp_src, wp_dst,
                                               observer, adaptation)

--- a/colormath/color_appearance_models.py
+++ b/colormath/color_appearance_models.py
@@ -690,8 +690,8 @@ class RLAB(object):
         :param y_n: Y value of reference white :math:`Y_n`.
         :param z_n: Z value of reference white :math:`Z_n`.
         :param y_n_abs: Absolute luminance :math:`Y_n` of a white object in cd/m^2.
-        :param sigma: Relative luminance parameter :math:`\sigma`. For average surround set :math:`\sigma=1/2.3`,
-                      for dim surround :math:`\sigma=1/2.9` and for dark surround :math:`\sigma=1/3.5`.
+        :param sigma: Relative luminance parameter :math:`\\sigma`. For average surround set :math:`\\sigma=1/2.3`,
+                      for dim surround :math:`\\sigma=1/2.9` and for dark surround :math:`\\sigma=1/3.5`.
         :param d: Degree of adaptation :math:`D`.
         """
         xyz = numpy.array([x, y, z])
@@ -796,7 +796,7 @@ class ATD95(object):
         :param y_0_abs: Absolute adapting luminance :math:`Y_0` in cd/m^2.
         :param k_1: :math:`k_1`
         :param k_2: :math:`k_2`
-        :param sigma: :math:`\sigma`
+        :param sigma: :math:`\\sigma`
         """
         xyz = self._scale_to_luminance(numpy.array([x, y, z]), y_0_abs)
         xyz_0 = self._scale_to_luminance(numpy.array([x_0, y_0, z_0]), y_0_abs)

--- a/colormath/color_conversions.py
+++ b/colormath/color_conversions.py
@@ -39,7 +39,7 @@ def apply_RGB_matrix(var1, var2, var3, rgb_type, convtype="xyz_to_rgb"):
     # Retrieve the appropriate transformation matrix from the constants.
     rgb_matrix = rgb_type.conversion_matrices[convtype]
 
-    logger.debug("  \* Applying RGB conversion matrix: %s->%s",
+    logger.debug("  \\* Applying RGB conversion matrix: %s->%s",
                  rgb_type.__class__.__name__, convtype)
     # Stuff the RGB/XYZ values into a NumPy matrix for conversion.
     var_matrix = numpy.array((
@@ -482,22 +482,22 @@ def XYZ_to_RGB(cobj, target_rgb, *args, **kwargs):
     temp_Y = cobj.xyz_y
     temp_Z = cobj.xyz_z
 
-    logger.debug("  \- Target RGB space: %s", target_rgb)
+    logger.debug("  \\- Target RGB space: %s", target_rgb)
     target_illum = target_rgb.native_illuminant
-    logger.debug("  \- Target native illuminant: %s", target_illum)
-    logger.debug("  \- XYZ color's illuminant: %s", cobj.illuminant)
+    logger.debug("  \\- Target native illuminant: %s", target_illum)
+    logger.debug("  \\- XYZ color's illuminant: %s", cobj.illuminant)
 
     # If the XYZ values were taken with a different reference white than the
     # native reference white of the target RGB space, a transformation matrix
     # must be applied.
     if cobj.illuminant != target_illum:
-        logger.debug("  \* Applying transformation from %s to %s ",
+        logger.debug("  \\* Applying transformation from %s to %s ",
                      cobj.illuminant, target_illum)
         # Get the adjusted XYZ values, adapted for the target illuminant.
         temp_X, temp_Y, temp_Z = apply_chromatic_adaptation(
             temp_X, temp_Y, temp_Z,
             orig_illum=cobj.illuminant, targ_illum=target_illum)
-        logger.debug("  \*   New values: %.3f, %.3f, %.3f",
+        logger.debug("  \\*   New values: %.3f, %.3f, %.3f",
                      temp_X, temp_Y, temp_Z)
 
     # Apply an RGB working space matrix to the XYZ values (matrix mul).

--- a/colormath/color_objects.py
+++ b/colormath/color_objects.py
@@ -458,14 +458,14 @@ class XYZColor(IlluminantMixin, ColorBase):
         This applies an adaptation matrix to change the XYZ color's illuminant.
         You'll most likely only need this during RGB conversions.
         """
-        logger.debug("  \- Original illuminant: %s", self.illuminant)
-        logger.debug("  \- Target illuminant: %s", target_illuminant)
+        logger.debug("  \\- Original illuminant: %s", self.illuminant)
+        logger.debug("  \\- Target illuminant: %s", target_illuminant)
 
         # If the XYZ values were taken with a different reference white than the
         # native reference white of the target RGB space, a transformation matrix
         # must be applied.
         if self.illuminant != target_illuminant:
-            logger.debug("  \* Applying transformation from %s to %s ",
+            logger.debug("  \\* Applying transformation from %s to %s ",
                          self.illuminant, target_illuminant)
             # Sets the adjusted XYZ values, and the new illuminant.
             apply_chromatic_adaptation_on_color(

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
 ]
 
 KEYWORDS = 'color math conversions'


### PR DESCRIPTION
Small changes were made to support 3.8 escaping deprecations whilst maintaining backward compatibility.