### PR TITLE
Correct the RGB clamping range for upscaled values

### DIFF
--- a/colormath/color_conversions.py
+++ b/colormath/color_conversions.py
@@ -33,7 +33,7 @@ def apply_RGB_matrix(var1, var2, var3, rgb_type, convtype="xyz_to_rgb"):
     Applies an RGB working matrix to convert from XYZ to RGB.
     The arguments are tersely named var1, var2, and var3 to allow for the
     passing of XYZ _or_ RGB values. var1 is X for XYZ, and R for RGB. var2 and
-    var3 follow suite.
+    var3 follow suit.
     """
     convtype = convtype.lower()
     # Retrieve the appropriate transformation matrix from the constants.
@@ -541,7 +541,7 @@ def XYZ_to_RGB(cobj, target_rgb, *args, **kwargs):
 @color_conversion_function(BaseRGBColor, XYZColor)
 def RGB_to_XYZ(cobj, target_illuminant=None, *args, **kwargs):
     """
-    RGB to XYZ conversion. Expects 0-255 RGB values.
+    RGB to XYZ conversion. Expects RGB values between 0 and 255.
 
     Based off of: http://www.brucelindbloom.com/index.html?Eqn_RGB_to_XYZ.html
     """

--- a/colormath/color_objects.py
+++ b/colormath/color_objects.py
@@ -510,11 +510,11 @@ class BaseRGBColor(ColorBase):
 
     def __init__(self, rgb_r, rgb_g, rgb_b, is_upscaled=False):
         """
-        :param float rgb_r: R coordinate. 0...1. 1-255 if is_upscaled=True.
-        :param float rgb_g: G coordinate. 0...1. 1-255 if is_upscaled=True.
-        :param float rgb_b: B coordinate. 0...1. 1-255 if is_upscaled=True.
+        :param float rgb_r: R coordinate. 0.0-1.0, or 0-255 if is_upscaled=True.
+        :param float rgb_g: G coordinate. 0.0-1.0, or 0-255 if is_upscaled=True.
+        :param float rgb_b: B coordinate. 0.0-1.0, or 0-255 if is_upscaled=True.
         :keyword bool is_upscaled: If False, RGB coordinate values are
-            beteween 0.0 and 1.0. If True, RGB values are between 1 and 255.
+            beteween 0.0 and 1.0. If True, RGB values are between 0 and 255.
         """
         super(BaseRGBColor, self).__init__()
         if is_upscaled:
@@ -539,7 +539,7 @@ class BaseRGBColor(ColorBase):
         if not self.is_upscaled:
             return min(max(coord, 0.0), 1.0)
         else:
-            return min(max(coord, 1), 255)
+            return min(max(coord, 0.0), 255.0)
 
     @property
     def clamped_rgb_r(self):
@@ -612,7 +612,7 @@ class sRGBColor(BaseRGBColor):
     :ivar float rgb_r: R coordinate
     :ivar float rgb_g: G coordinate
     :ivar float rgb_b: B coordinate
-    :ivar bool is_upscaled: If True, RGB values are between 1-255. If False,
+    :ivar bool is_upscaled: If True, RGB values are between 0-255. If False,
         0.0-1.0.
     """
 
@@ -645,7 +645,7 @@ class BT2020Color(BaseRGBColor):
     :ivar float rgb_r: R coordinate
     :ivar float rgb_g: G coordinate
     :ivar float rgb_b: B coordinate
-    :ivar bool is_upscaled: If True, RGB values are between 1-255. If False,
+    :ivar bool is_upscaled: If True, RGB values are between 0-255. If False,
         0.0-1.0.
     """
 
@@ -678,7 +678,7 @@ class AdobeRGBColor(BaseRGBColor):
     :ivar float rgb_r: R coordinate
     :ivar float rgb_g: G coordinate
     :ivar float rgb_b: B coordinate
-    :ivar bool is_upscaled: If True, RGB values are between 1-255. If False,
+    :ivar bool is_upscaled: If True, RGB values are between 0-255. If False,
         0.0-1.0.
     """
 
@@ -711,7 +711,7 @@ class AppleRGBColor(BaseRGBColor):
     :ivar float rgb_r: R coordinate
     :ivar float rgb_g: G coordinate
     :ivar float rgb_b: B coordinate
-    :ivar bool is_upscaled: If True, RGB values are between 1-255. If False,
+    :ivar bool is_upscaled: If True, RGB values are between 0-255. If False,
         0.0-1.0.
     """
 

--- a/doc_src/conversions.rst
+++ b/doc_src/conversions.rst
@@ -85,12 +85,12 @@ RGB conversions and out-of-gamut coordinates
 
 RGB spaces tend to have a smaller gamut than some of the CIE color spaces.
 When converting to RGB, this can cause some of the coordinates to end up
-being out of the acceptable range (0.0-1.0 or 1-255, depending on whether
+being out of the acceptable range (0.0-1.0 or 0-255, depending on whether
 your RGB color is upscaled).
 
 Rather than clamp these for you, we leave them as-is. This allows for more
 accurate conversions back to the CIE color spaces. If you require the clamped
-(0.0-1.0 or 1-255) values, use the following properties on any RGB color:
+(0.0-1.0 or 0-255) values, use the following properties on any RGB color:
 
 * ``clamped_rgb_r``
 * ``clamped_rgb_g``


### PR DESCRIPTION
Use the correct clamping range (should be 0-255 not 1-255)
Made documentations consistent for upscaling ranges.

Fixes #66