### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/colormath/color_diff.py
+++ b/colormath/color_diff.py
@@ -43,7 +43,7 @@ def delta_e_cie1976(color1, color2):
     color1_vector = _get_lab_color1_vector(color1)
     color2_matrix = _get_lab_color2_matrix(color2)
     delta_e = color_diff_matrix.delta_e_cie1976(color1_vector, color2_matrix)[0]
-    return numpy.asscalar(delta_e)
+    return delta_e.item()
 
 
 # noinspection PyPep8Naming
@@ -65,7 +65,7 @@ def delta_e_cie1994(color1, color2, K_L=1, K_C=1, K_H=1, K_1=0.045, K_2=0.015):
     color2_matrix = _get_lab_color2_matrix(color2)
     delta_e = color_diff_matrix.delta_e_cie1994(
         color1_vector, color2_matrix, K_L=K_L, K_C=K_C, K_H=K_H, K_1=K_1, K_2=K_2)[0]
-    return numpy.asscalar(delta_e)
+    return delta_e.item()
 
 
 # noinspection PyPep8Naming
@@ -77,7 +77,7 @@ def delta_e_cie2000(color1, color2, Kl=1, Kc=1, Kh=1):
     color2_matrix = _get_lab_color2_matrix(color2)
     delta_e = color_diff_matrix.delta_e_cie2000(
         color1_vector, color2_matrix, Kl=Kl, Kc=Kc, Kh=Kh)[0]
-    return numpy.asscalar(delta_e)
+    return delta_e.item()
 
 
 # noinspection PyPep8Naming
@@ -93,4 +93,4 @@ def delta_e_cmc(color1, color2, pl=2, pc=1):
     color2_matrix = _get_lab_color2_matrix(color2)
     delta_e = color_diff_matrix.delta_e_cmc(
         color1_vector, color2_matrix, pl=pl, pc=pc)[0]
-    return numpy.asscalar(delta_e)
+    return delta_e.item()


### PR DESCRIPTION
numpy.asscalar function is deprecated since NumPy v1.16

See:
https://docs.scipy.org/doc/numpy-1.16.0/release.html#new-deprecations