### PR TITLE
Making networkx package version more explicit.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-networkx>=2.0
+networkx>=2.0,<=2.4
 numpy
 nose


### PR DESCRIPTION
The networkx 2.5 dropped support of python 3.5.  Look here https://networkx.github.io/documentation/latest/news.html