### PR TITLE
docs: Fix a few typos

### DIFF
--- a/colormath/color_appearance_models.py
+++ b/colormath/color_appearance_models.py
@@ -821,7 +821,7 @@ class RLAB(object):
             # dimension separately. First figure out how many values we have to
             # deal with.
             input_dim = len(x)
-            # No create the ouput array that we will fill layer by layer
+            # No create the output array that we will fill layer by layer
             xyz_ref = numpy.zeros((3, input_dim))
             for layer in range(input_dim):
                 a = numpy.diag(lms_a[..., layer])

--- a/colormath/color_objects.py
+++ b/colormath/color_objects.py
@@ -606,7 +606,7 @@ class BaseRGBColor(ColorBase):
         :param float rgb_g: G coordinate. 0.0-1.0, or 0-255 if is_upscaled=True.
         :param float rgb_b: B coordinate. 0.0-1.0, or 0-255 if is_upscaled=True.
         :keyword bool is_upscaled: If False, RGB coordinate values are
-            beteween 0.0 and 1.0. If True, RGB values are between 0 and 255.
+            between 0.0 and 1.0. If True, RGB values are between 0 and 255.
         """
         super(BaseRGBColor, self).__init__()
         if is_upscaled:


### PR DESCRIPTION
There are small typos in:
- colormath/color_appearance_models.py
- colormath/color_objects.py

Fixes:
- Should read `output` rather than `ouput`.
- Should read `between` rather than `beteween`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md